### PR TITLE
discard cue when start / end times are invalid

### DIFF
--- a/lib/parser.rb
+++ b/lib/parser.rb
@@ -150,6 +150,8 @@ module WebVTT
         @start = Timestamp.new $1
         @end = Timestamp.new $2
         @style = Hash[$3.strip.split(" ").map{|s| s.split(":").map(&:strip) }]
+      else
+        return
       end
       @text = lines[1..-1].join("\n")
     end

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -210,4 +210,10 @@ The text should change)
     webvtt = WebVTT.convert_from_srt("tests/subtitles/invalid_cue.srt")
     assert_equal 1, webvtt.cues.size
   end
+
+  def test_invalid_cue_time
+    cue_string = open("tests/subtitles/invalid_cue_time.srt").read
+    cue = WebVTT::Cue.parse(cue_string)
+    assert_nil cue.text
+  end
 end

--- a/tests/subtitles/invalid_cue_time.srt
+++ b/tests/subtitles/invalid_cue_time.srt
@@ -1,0 +1,3 @@
+9999
+00:00:0,500 --> 00:00:2,00
+<font color="#ffff00" size=14>www.tvsubtitles.net</font>


### PR DESCRIPTION
Without the patch
```
9999
00:00:0,500 --> 00:00:2,00
<font color="#ffff00" size=14>www.tvsubtitles.net</font>
```
is converted to
```
9999
-->
<font color="#ffff00" size=14>www.tvsubtitles.net</font>
```

with missing timestamps in the cue, generating invalid webvtt output