### PR TITLE
Permit files with multiple newlines between blocks

### DIFF
--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -52,7 +52,7 @@ module WebVTT
       # remove bom first
       @content.gsub!("\uFEFF", '')
 
-      cues = @content.split("\n\n")
+      cues = @content.split(/\n\n+/)
       @header = cues.shift
       header_lines = @header.split("\n").map(&:strip)
       if (header_lines[0] =~ /^WEBVTT/).nil?

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -64,6 +64,11 @@ class ParserTest < Minitest::Test
     assert_equal "English subtitle 16 -Unforced- (00:00:31.000)\nalign:start line:0%", cue.text
   end
 
+  def test_multiple_line_separators
+    webvtt = WebVTT.read("tests/subtitles/test_multiple_line_separators.vtt")
+    assert_equal 2, webvtt.cues.length
+  end
+
   def test_ignore_if_note
     webvtt = WebVTT.read("tests/subtitles/withnote.vtt")
     assert_equal 3, webvtt.cues.size

--- a/tests/subtitles/test_multiple_line_separators.vtt
+++ b/tests/subtitles/test_multiple_line_separators.vtt
@@ -1,0 +1,15 @@
+WEBVTT X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
+
+
+
+
+00:00:29.000 --> 00:00:31.000 line:75%
+English subtitle 15 -Forced- (00:00:27.000)
+line:75%
+
+
+
+
+00:00:31.000 --> 00:00:33.000 align:start line:0%
+English subtitle 16 -Unforced- (00:00:31.000)
+align:start line:0%


### PR DESCRIPTION
Hi there - I ran across a case today where I think webvtt-ruby is refusing some valid input, so I thought I'd submit a fix.

The WebVTT [file structure spec](https://w3c.github.io/webvtt/#file-structure) specifies that style, comment and cue blocks are to be separated from each other by one or more WebVTT line terminators. The following should therefore be considered valid input:

    WEBVTT




    00:00:29.000 --> 00:00:31.000 line:75%
    English subtitle 15 -Forced- (00:00:27.000)
    line:75%





    00:00:31.000 --> 00:00:33.000 align:start line:0%
    English subtitle 16 -Unforced- (00:00:31.000)
    align:start line:0%

However, the parser currently generates blocks by [splitting the input on "\n\n"](https://github.com/opencoconut/webvtt-ruby/blob/82106b0e8ab889e8770a58d970036dccfeed6b82/lib/webvtt/parser.rb#L55). When there are more than two newlines between blocks, this results in empty strings being interpreted as cue blocks, in turn causing an exception to be raised when Cue.parse is invoked.

This PR alters the content chunking to split on the presence of two or more linefeed characters instead, so any extra blank lines will be consumed without parsing.

Hope this looks okay - if you have any questions or suggestions for edits, just let me know. :)

Cheers,
Simon