### PR TITLE
allow creation of an empty WebVTT::Blob

### DIFF
--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -31,9 +31,16 @@ module WebVTT
     attr_reader :header
     attr_accessor :cues
 
-    def initialize(content)
-      @content = content.gsub("\r\n", "\n").gsub("\r","\n") # normalizing new line character
-      parse
+    def initialize(content = nil)
+      @cues = []
+
+      if content
+        parse(
+          content.gsub("\r\n", "\n").gsub("\r","\n") # normalizing new line character
+        )
+      else
+        @header = 'WEBVTT'
+      end
     end
 
     def to_webvtt
@@ -48,11 +55,11 @@ module WebVTT
       @cues.last.end_in_sec - @cues.first.start_in_sec
     end
 
-    def parse
+    def parse(content)
       # remove bom first
-      @content.gsub!("\uFEFF", '')
+      content.gsub!("\uFEFF", '')
 
-      cues = @content.split("\n\n")
+      cues = content.split("\n\n")
       @header = cues.shift
       header_lines = @header.split("\n").map(&:strip)
       if (header_lines[0] =~ /^WEBVTT/).nil?

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -20,6 +20,12 @@ class ParserTest < Minitest::Test
     }
   end
 
+  def test_can_create_empty_webvtt
+    webvtt = WebVTT::Blob.new
+    assert_equal 'WEBVTT', webvtt.header
+    assert_equal [], webvtt.cues
+  end
+
   def test_list_cues
     webvtt = WebVTT.read("tests/subtitles/test.vtt")
     assert_instance_of Array, webvtt.cues
@@ -164,7 +170,7 @@ The text should change)
     assert_equal "00:09:02.373", webvtt.cues[1].end.to_s
     assert_equal "", webvtt.cues[1].text
   end
-  
+
   def test_cue_offset_by
     cue = WebVTT::Cue.parse <<-CUE
     00:00:01.000 --> 00:00:25.432


### PR DESCRIPTION
i need to create a WebVTT file from captions stored in a relational database. this is currently inconvenient because `WebVTT::Blob` and `WebVTT::File` constructors expect to get some content to parse.

```ruby
# this workaround is possible with current code, but feels like a hack.
instance = WebVTT::Blob.new('WEBVTT')

# code in this PR allows
instance = WebVTT::Blob.new
```

i removed `@content` because it is only used to pass data from `#initialize` to `#parse`. it's never utilized anywhere else in the class. i could put it back if there are any concerns about the change in `#parse`'s signature. (seemed like an improvement to me, but i'm happy to revert if it's objectionable.)