### PR TITLE
Use File.exist? for Ruby 3.2.0 compatibility

### DIFF
--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -9,7 +9,7 @@ module WebVTT
   end
 
   def self.convert_from_srt(srt_file, output=nil)
-    if !::File.exists?(srt_file)
+    if !::File.exist?(srt_file)
       raise InputError, "SRT file not found"
     end
 
@@ -84,7 +84,7 @@ module WebVTT
     attr_reader :path, :filename
 
     def initialize(webvtt_file)
-      if !::File.exists?(webvtt_file)
+      if !::File.exist?(webvtt_file)
         raise InputError, "WebVTT file not found"
       end
 

--- a/tests/segmenter.rb
+++ b/tests/segmenter.rb
@@ -43,7 +43,7 @@ class ParserTest < Minitest::Test
     subs = segmenter.split_to_files
     segmenter.generate_playlist(subs)
 
-    assert File.exists?("test.m3u8")
+    assert File.exist?("test.m3u8")
     # clean up
     subs.each {|f| FileUtils.rm(f.filename)}
     FileUtils.rm("test.m3u8")


### PR DESCRIPTION
Fixes https://github.com/opencoconut/webvtt-ruby/issues/19!

This small :pinching_hand: PR replaces `File.exists?` with `File.exist?`.

No functional changes are introduced in this PR.  `File.exists?` was deprecated in Ruby 3.2.0 and later, and `File.exist?` is backward-compatible with older versions of Ruby.