### PR TITLE
Raise MalformedFile exception if cue doesn't have timestamps

### DIFF
--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -172,6 +172,8 @@ module WebVTT
         @start = Timestamp.new $1
         @end = Timestamp.new $3
         @style = Hash[$5.strip.split(" ").map{|s| s.split(":").map(&:strip) }]
+      else
+        raise WebVTT::MalformedFile
       end
       @text = lines[1..-1].join("\n")
     end

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -251,4 +251,9 @@ The text should change)
     assert_equal 15, webvtt.cues.size
   end
 
+  def test_invalid_vtt_without_milliseconds
+    assert_raises WebVTT::MalformedFile do
+      vtt = WebVTT::File.new('tests/subtitles/no_milliseconds.vtt')
+    end
+  end
 end


### PR DESCRIPTION
This small PR is to have a stricter enforcement of the WebVTT spec: this would have the parser raise a MalformedFile exception if the timestamp is either incorrect or is missing a part (milliseconds for example).

Given the [WebVTT spec](https://html.spec.whatwg.org/multipage/media.html#text-track-cue) specifies that the Timestamps are a requirement, this would further improve the detection of incorrect VTT files.

It would also be pretty cool to have this validation enforced 😁 

Thank you for all your work on this!