### PR TITLE
Ignore style block and remove style tags from cue text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ webvtt.cues.each do |cue|
   puts "Start: #{cue.start}"
   puts "End: #{cue.end}"
   puts "Style: #{cue.style.inspect}"
-  puts "Text: #{cue.text}"
+  puts "Text: #{cue.text}" # text without style tags (if any)
+  puts "Raw text: #{cue.raw_text}" # text with style tags
   puts "--"
 end
 ```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ webvtt.cues.each do |cue|
   puts "Start: #{cue.start}"
   puts "End: #{cue.end}"
   puts "Style: #{cue.style.inspect}"
-  puts "Text: #{cue.text}" # text without style tags (if any)
-  puts "Raw text: #{cue.raw_text}" # text with style tags
+  puts "Text: #{cue.text}"
+  puts "Plain text: #{cue.plain_text}" # text without style tags if any
   puts "--"
 end
 ```

--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -104,7 +104,7 @@ module WebVTT
   end
 
   class Cue
-    attr_accessor :identifier, :start, :end, :style, :text
+    attr_accessor :identifier, :start, :end, :style, :text, :raw_text
 
     def initialize(cue = nil)
       @content = cue
@@ -177,9 +177,8 @@ module WebVTT
       end
 
 
-
-      @text = lines[1..-1].join("\n").
-        gsub(/<.+?>/, '').strip # remove style tags from text
+      @raw_text = lines[1..-1].join("\n")
+      @text = @raw_text.gsub(/<.+?>/, '').strip # remove style tags from text
     end
   end
 

--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -104,7 +104,7 @@ module WebVTT
   end
 
   class Cue
-    attr_accessor :identifier, :start, :end, :style, :text, :raw_text
+    attr_accessor :identifier, :start, :end, :style, :text, :plain_text
 
     def initialize(cue = nil)
       @content = cue
@@ -177,8 +177,8 @@ module WebVTT
       end
 
 
-      @raw_text = lines[1..-1].join("\n")
-      @text = @raw_text.gsub(/<.+?>/, '').strip # remove style tags from text
+      @text = lines[1..-1].join("\n")
+      @plain_text = @text.gsub(/<.+?>/, '').strip # remove style tags from text
     end
   end
 

--- a/lib/webvtt/parser.rb
+++ b/lib/webvtt/parser.rb
@@ -156,8 +156,8 @@ module WebVTT
     def parse
       lines = @content.split("\n").map(&:strip)
 
-      # it's a note, ignore
-      return if lines[0] =~ /NOTE/
+      # it's a note or style section, ignore
+      return if lines[0] =~ /NOTE|STYLE/
 
       if !lines[0].include?("-->")
         @identifier = lines[0]
@@ -175,7 +175,11 @@ module WebVTT
       else
         raise WebVTT::MalformedFile
       end
-      @text = lines[1..-1].join("\n")
+
+
+
+      @text = lines[1..-1].join("\n").
+        gsub(/<.+?>/, '').strip # remove style tags from text
     end
   end
 

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -87,8 +87,8 @@ class ParserTest < Minitest::Test
     assert_equal 1, webvtt.cues.size
     # ignoring the first cue which is a NOTE
     assert_equal "hello", webvtt.cues[0].identifier
-    assert_equal "Hello world.", webvtt.cues[0].text
-    assert_equal "Hello <b>world</b>.", webvtt.cues[0].raw_text
+    assert_equal "Hello world.", webvtt.cues[0].plain_text
+    assert_equal "Hello <b>world</b>.", webvtt.cues[0].text
   end
 
   def test_timestamp_in_sec
@@ -258,11 +258,5 @@ The text should change)
     assert !webvtt.cues.empty?, "Cues should not be empty"
     assert_instance_of WebVTT::Cue, webvtt.cues[0]
     assert_equal 15, webvtt.cues.size
-  end
-
-  def test_invalid_vtt_without_milliseconds
-    assert_raises WebVTT::MalformedFile do
-      vtt = WebVTT::File.new('tests/subtitles/no_milliseconds.vtt')
-    end
   end
 end

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -82,6 +82,14 @@ class ParserTest < Minitest::Test
     assert_equal "1", webvtt.cues[0].identifier
   end
 
+  def test_ignore_style_and_remove_style_tag_from_cue_text
+    webvtt = WebVTT.read("tests/subtitles/withstyle.vtt")
+    assert_equal 1, webvtt.cues.size
+    # ignoring the first cue which is a NOTE
+    assert_equal "hello", webvtt.cues[0].identifier
+    assert_equal "Hello world.", webvtt.cues[0].text
+  end
+
   def test_timestamp_in_sec
     assert_equal 60.0, WebVTT::Cue.timestamp_in_sec("00:01:00.000")
     assert_equal 126.23, WebVTT::Cue.timestamp_in_sec("00:02:06.230")

--- a/tests/parser.rb
+++ b/tests/parser.rb
@@ -88,6 +88,7 @@ class ParserTest < Minitest::Test
     # ignoring the first cue which is a NOTE
     assert_equal "hello", webvtt.cues[0].identifier
     assert_equal "Hello world.", webvtt.cues[0].text
+    assert_equal "Hello <b>world</b>.", webvtt.cues[0].raw_text
   end
 
   def test_timestamp_in_sec

--- a/tests/subtitles/withstyle.vtt
+++ b/tests/subtitles/withstyle.vtt
@@ -1,0 +1,20 @@
+WEBVTT
+
+NOTE This example is from https://www.w3.org/TR/webvtt1/#styling
+
+STYLE
+::cue {
+  background-image: linear-gradient(to bottom, dimgray, lightgray);
+  color: papayawhip;
+}
+
+NOTE comment blocks can be used between style blocks.
+
+STYLE
+::cue(b) {
+  color: peachpuff;
+}
+
+hello
+00:00:00.000 --> 00:00:10.000
+Hello <b>world</b>.


### PR DESCRIPTION
Thanks for sharing this tool. Helped a lot.

I just wanted to push an update to the parser because WEBVTT can have style block and tags. In my case, I have STYLE blocks and it raises `MalformedFile` error for my VTT.

Reference: https://www.w3.org/TR/webvtt1/#styling

Hopefully, someone is still checking the PRs ಠ‿ಠ

Cheers.